### PR TITLE
Fix SDL Mixer initialization

### DIFF
--- a/src/system/sdl/SDLAudioContext.cpp
+++ b/src/system/sdl/SDLAudioContext.cpp
@@ -24,8 +24,8 @@ static constexpr int SDL_MIX_FLAGS = MIX_INIT_OGG
 const std::string LOG_TAG("audio");
 
 SDLAudioContext::SDLAudioContext()
-    : audio_loader(SDL_MIX_FLAGS)
-    , mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 1024)
+    : mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 1024)
+    , audio_loader(SDL_MIX_FLAGS)
 {
     SDLMusic::mixer = &mixer;
     SDLSoundEffect::mixer = &mixer;

--- a/src/system/sdl/SDLAudioContext.h
+++ b/src/system/sdl/SDLAudioContext.h
@@ -20,6 +20,6 @@ public:
     void toggleMusicMute() final;
 
 private:
-    SDL2pp::SDLMixer audio_loader;
     SDL2pp::Mixer mixer;
+    SDL2pp::SDLMixer audio_loader;
 };


### PR DESCRIPTION
Workaround for the Mix_Init issues of SDL Mixer 2.0.2, see #18.
