### PR TITLE
Use NULL instead of "." for SDL_GetPrefPath

### DIFF
--- a/src/system/Paths.cpp
+++ b/src/system/Paths.cpp
@@ -20,7 +20,7 @@ std::string defaultDataDir()
 
 std::string defaultConfigDir()
 {
-    const auto path_raw = SDL_GetPrefPath(".", "openblok");
+    const auto path_raw = SDL_GetPrefPath(NULL, "openblok");
     const std::string path(path_raw);
     SDL_free(path_raw);
     return path;


### PR DESCRIPTION
I've looked at the code in SDL and this is the preferred method to not set the organization. It's a bit odd, that it's not documented like that. I've used code like this on Linux, Windows, PS Vita and PSP. The SDL test which verifies this works can be found here in case there is any doubt: https://github.com/libsdl-org/SDL/blob/f0e768da43173cf62732fc20d1f80eb777d6d5c8/test/testfilesystem.c#L49