### PR TITLE
Fix Vita build not working

### DIFF
--- a/src/system/CMakeLists.txt
+++ b/src/system/CMakeLists.txt
@@ -70,6 +70,7 @@ endif()
 
 if(VITA)
     target_link_libraries(module_system
+        SDL2
         webp
         pthread
         png
@@ -80,9 +81,11 @@ if(VITA)
         jpeg
         z
         mikmod
+        modplug
         mpg123
         FLAC
         SceAudio_stub
+        SceAudioIn_stub
         SceCommonDialog_stub
         SceCtrl_stub
         SceDisplay_stub


### PR DESCRIPTION
Some changes were made in the VitaSDK, causing some build issues. Unfortunately adding SDL2 to this list is required. The VitaSDK requires a specific order for SDL2 and SDL2_mixer which was causing it to not build and this workaround works.